### PR TITLE
Add flight timetable page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ This repository hosts a simple webpage built with HTML5 and CSS animations.
 It includes a JavaScript-based fireworks effect rendered on a canvas layer.
 Fireworks now launch automatically at random intervals from random positions.
 Click anywhere on the page to launch additional bursts of particles.
+
+## Flights Timetable
+
+The `flights.html` page attempts to retrieve flight timetable data from the Taoyuan Airport website via a JSON API. Due to network restrictions in this environment, the actual API endpoint could not be verified. The JavaScript fetches data from a placeholder URL (`https://www.taoyuan-airport.com/api/flight_timetable`). Replace this URL with the correct endpoint if available.
+
+Open `flights.html` in a browser with network access to view the timetable. If the API requires additional headers or authentication, modify `flights.js` accordingly.

--- a/flights.html
+++ b/flights.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Flight Timetable</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="content">
+      <h1>Taoyuan Airport Flight Timetable</h1>
+      <p id="status">Loading...</p>
+      <table id="flights-table" style="display:none">
+        <thead>
+          <tr>
+            <th>Flight</th>
+            <th>From/To</th>
+            <th>Time</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
+    </div>
+    <script src="flights.js"></script>
+  </body>
+</html>

--- a/flights.js
+++ b/flights.js
@@ -1,0 +1,39 @@
+// flights.js
+// Fetches flight timetable data from Taoyuan Airport API and displays it
+
+document.addEventListener('DOMContentLoaded', () => {
+  const statusEl = document.getElementById('status');
+  const tableEl = document.getElementById('flights-table');
+  const tbodyEl = tableEl.querySelector('tbody');
+
+  // Placeholder API endpoint. Replace with real endpoint if available.
+  const API_URL = 'https://www.taoyuan-airport.com/api/flight_timetable';
+
+  fetch(API_URL)
+    .then((resp) => {
+      if (!resp.ok) throw new Error('Network response was not ok');
+      return resp.json();
+    })
+    .then((data) => {
+      if (!Array.isArray(data)) {
+        statusEl.textContent = 'Unexpected API response';
+        return;
+      }
+      data.forEach((flight) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${flight.flightNo || ''}</td>
+          <td>${flight.route || ''}</td>
+          <td>${flight.time || ''}</td>
+          <td>${flight.status || ''}</td>
+        `;
+        tbodyEl.appendChild(row);
+      });
+      statusEl.style.display = 'none';
+      tableEl.style.display = 'table';
+    })
+    .catch((err) => {
+      console.error(err);
+      statusEl.textContent = 'Failed to load data.';
+    });
+});


### PR DESCRIPTION
## Summary
- add a new `flights.html` page with a table for flight data
- add `flights.js` script to fetch timetable data from a placeholder API endpoint
- document how to update the endpoint in `README.md`

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68412d96355c8326a2953959266f6851