### PR TITLE
Add sample page showing IP and time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # giLrv5.github.io
-網站
+
+這是一個靜態網站範例。`index.html` 會顯示造訪者的 IP 與當前時間。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>測試網頁</title>
+    <style>
+        body { font-family: sans-serif; padding: 2rem; }
+        #container { margin: 0 auto; max-width: 600px; }
+        .label { font-weight: bold; }
+    </style>
+</head>
+<body>
+    <div id="container">
+        <h1>測試網頁</h1>
+        <p><span class="label">您的 IP: </span><span id="ip">讀取中...</span></p>
+        <p><span class="label">現在時間: </span><span id="time">讀取中...</span></p>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // 取得使用者 IP
+            fetch('https://api.ipify.org?format=json')
+                .then(function (response) { return response.json(); })
+                .then(function (data) {
+                    document.getElementById('ip').textContent = data.ip;
+                })
+                .catch(function () {
+                    document.getElementById('ip').textContent = '無法取得 IP';
+                });
+
+            function updateTime() {
+                var now = new Date();
+                document.getElementById('time').textContent = now.toLocaleString();
+            }
+            updateTime();
+            setInterval(updateTime, 1000);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` page that shows the visitor's IP address and the current time
- update README to mention the example site

## Testing
- `npm test` *(fails: Could not read package.json)*
- `html5validator --root . --show-warnings`


------
https://chatgpt.com/codex/tasks/task_e_6887931144888326b4b953fc656958c8