### PR TITLE
新增舒爾特方格（1~25）連結

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
       <h1>歡迎來到我的介紹網頁</h1>
       <p>這裡整理了我的練習內容，歡迎點擊以下連結：</p>
       <p><a href="https://gilrv5.github.io/CountJump/">數字順序練習</a></p>
+      <p><a href="https://gilrv5.github.io/Number_Hunt_Grid/">舒爾特方格（1~25）</a></p>
     </main>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- 在首頁提供對練習項目的直接連結以方便存取，新增「舒爾特方格（1~25）」以指向現有的練習頁面。

### Description
- 在 `index.html` 中新增一行連結 `<a href="https://gilrv5.github.io/Number_Hunt_Grid/">舒爾特方格（1~25）</a>`，以顯示於首頁練習清單中。

### Testing
- 已使用 `python3 -m http.server 4173` 啟動本地伺服器並以 Playwright 執行 `page.goto('http://127.0.0.1:4173')` 並截圖驗證連結顯示，測試成功。 
- 已使用 `git add` + `git commit` 提交變更，提交成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c22e28b083269bd9f76eb208036e)