### PR TITLE
Improve sitemap publishing reliability

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll processing so static files such as sitemap.xml are published as-is.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,11 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://gilrv5.github.io/</loc>
+    <lastmod>2026-06-27</lastmod>
   </url>
   <url>
     <loc>https://gilrv5.github.io/CountJump/</loc>
+    <lastmod>2026-06-27</lastmod>
   </url>
   <url>
     <loc>https://gilrv5.github.io/Number_Hunt_Grid/</loc>
+    <lastmod>2026-06-27</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
### Motivation
- Address Google Search Console sitemap indexing failures by ensuring the sitemap is published as a static file rather than being altered by Jekyll processing. 
- Make the sitemap more explicit for crawlers by providing `lastmod` timestamps for each URL. 

### Description
- Add a `.nojekyll` file to disable Jekyll so static files such as `sitemap.xml` are published as-is. 
- Add `<lastmod>2026-06-27</lastmod>` entries to each URL in `sitemap.xml` to include update timestamps for crawlers. 
- Keep `sitemap.xml` well-formed XML so parsers can read it without errors. 

### Testing
- Parsed the updated `sitemap.xml` with `python3` and `xml.etree.ElementTree` which succeeded. 
- Served the site locally with `python3 -m http.server` and fetched the served `sitemap.xml` with `curl` then parsed it with `xml.etree.ElementTree`, which succeeded. 
- Attempted to `curl -I -L https://gilrv5.github.io/sitemap.xml` from the runner but that request failed due to an environment proxy returning `CONNECT tunnel failed, response 403`, so live site validation from the runner could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb47292e883269a31e47f98d03e66)